### PR TITLE
Build successfully on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Furo is distributed on [PyPI]. To use the theme in your Sphinx project:
    html_theme = "furo"
    ```
 
-3. Your Sphinx documentation's HTML pages will now be generated with this theme! 🎉
+3. Your Sphinx documentation's HTML pages will now be generated with this theme!
 
 [pypi]: https://pypi.org/project/furo/
 


### PR DESCRIPTION
Installing from source on Windows fails during the "preparing metadata" stage. This is the culprit:

```
  generate_metadata(dist_info / "METADATA").write_text(project.get_metadata_file_contents())

  UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f389' in position 3871: character maps to <undefined>
```

It turns out that character is 🎉, aka party popper, which does appear in README.md. If we remove it, the Windows build succeeds?